### PR TITLE
feat!: add iteratePages and refactor interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,25 @@ npm i @rpidanny/google-scholar
 For basic usage, you can use the helper functions `search` and `parseUrl` provided by the library. These functions are straightforward and easy to use.
 
 ```typescript
-import { search } from '@rpidanny/google-scholar'
+import { iteratePages, parseUrl, search } from '@rpidanny/google-scholar'
 
-// Search using keywords
-const result = await search({
+const searchOpts = {
   keywords: 'crispr cas9',
   yearLow: 2000, // [Optional] paper published after
   yearHigh: 2024, // [Optional] paper published before
   authors: ['JA Doudna', 'E Charpentier'], // [Optional] Papers from authors
-})
-console.log(JSON.stringify(result, null, 2))
+}
+
+// Get the 1st page content for a search option
+const pageContent = await search(searchOpts)
+console.log(JSON.stringify(pageContent, null, 2))
 
 // Parse page using url
-const result2 = await parseUrl('https://scholar.google.com/scholar?q=crispr+cas9&hl=en')
-console.log(JSON.stringify(result2, null, 2))
+const pageContent2 = await parseUrl('https://scholar.google.com/scholar?q=crispr+cas9&hl=en')
+console.log(JSON.stringify(pageContent2, null, 2))
+
+// Iterate over all available pages
+await iteratePages(searchOpts, pageContent => JSON.stringify(pageContent, null, 2))
 ```
 
 ### Advanced Usage
@@ -50,11 +55,13 @@ async function searchGoogleScholar(keywords: string) {
 searchGoogleScholar('crispr cas9')
 ```
 
+> Tip: Utilize [Odysseus](https://github.com/rpidanny/odysseus) as a WebClient to handle Google Captcha. It opens pages in a browser, allowing human solving of captchas to seamlessly continue the scraping process.
+
 ### Example Response
 
 ```json
 {
-  "results": [
+  "papers": [
     {
       "title": "CRISPR–Cas9 structures and mechanisms",
       "url": "https://www.annualreviews.org/doi/abs/10.1146/annurev-biophys-062215-010822",
@@ -80,7 +87,7 @@ searchGoogleScholar('crispr cas9')
       "relatedArticlesUrl": "https://scholar.google.com/scholar?q=related:WMW1j8HoFyIJ:scholar.google.com/&scioq=crispr+cas9&hl=en&as_sdt=0,5"
     }
   ],
-  "count": 594000,
+  "totalPapers": 594000,
   "nextUrl": "https://scholar.google.com/scholar?start=10&q=crispr+cas9&hl=en&as_sdt=0,5",
   "prevUrl": null
 }

--- a/examples/advanced-usage.ts
+++ b/examples/advanced-usage.ts
@@ -8,11 +8,16 @@ const odysseus = new Odysseus({ headless: false }, logger)
 
 const googleScholar = new GoogleScholar(odysseus, logger)
 
-async function searchGoogleScholar(query: string) {
-  const result = await googleScholar.search(query)
+async function searchGoogleScholar({ keywords, yearLow, yearHigh, authors }) {
+  const result = await googleScholar.search({ keywords, yearLow, yearHigh, authors })
   console.log(JSON.stringify(result, null, 2))
 
   await odysseus.close()
 }
 
-searchGoogleScholar('crispr cas9')
+searchGoogleScholar({
+  keywords: 'crispr cas9',
+  yearLow: 2_000,
+  yearHigh: 2_024,
+  authors: ['JA Doudna', 'E Charpentier'],
+})

--- a/examples/search.ts
+++ b/examples/search.ts
@@ -1,7 +1,7 @@
 import { search } from '../src'
 
 async function main() {
-  const result = await search('crispr cas9')
+  const result = await search({ keywords: 'crispr cas9' })
   console.log(JSON.stringify(result, null, 2))
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -18,7 +18,7 @@ export interface ICitation {
   url: string | null
 }
 
-export interface IGoogleScholarResult {
+export interface IPaperMetadata {
   title: string
   url: string
   authors: IAuthor[]
@@ -28,13 +28,13 @@ export interface IGoogleScholarResult {
   citation: ICitation
 }
 
-export interface ISearchResponse {
-  results: IGoogleScholarResult[]
-  count: number
+export interface IPageContent {
+  papers: IPaperMetadata[]
+  totalPapers: number
   nextUrl: string | null
   prevUrl: string | null
-  next: (() => Promise<ISearchResponse>) | null
-  previous: (() => Promise<ISearchResponse>) | null
+  next: (() => Promise<IPageContent>) | null
+  previous: (() => Promise<IPageContent>) | null
 }
 
 export interface ICitations {

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -1,14 +1,32 @@
 import { GoogleScholar } from './google-scholar'
-import { ISearchOptions, ISearchResponse } from './interfaces'
+import { IPageContent, ISearchOptions } from './interfaces'
 import { SimpleWebClient } from './simple-web-client'
 
 const webClient = new SimpleWebClient()
 const googleScholar = new GoogleScholar(webClient)
 
-export async function search(opts: ISearchOptions): Promise<ISearchResponse> {
+/*
+ * Searches google scholar with the given search options and returns the concent of the first page
+ */
+export async function search(opts: ISearchOptions): Promise<IPageContent> {
   return googleScholar.search(opts)
 }
 
-export async function parseUrl(url: string): Promise<ISearchResponse> {
+/*
+ * Parses the given google scholar url
+ */
+export async function parseUrl(url: string): Promise<IPageContent> {
   return googleScholar.parseUrl(url)
+}
+
+/*
+ * Iterates through all search result pages,
+ * invoking the provided function on each page until it returns false
+ * or there are no more pages.
+ */
+export async function iteratePages(
+  opts: ISearchOptions,
+  onPage: (page: IPageContent) => boolean,
+): Promise<void> {
+  return googleScholar.iteratePages(opts, onPage)
 }

--- a/test/data/page1.json
+++ b/test/data/page1.json
@@ -1,5 +1,5 @@
 {
-  "results": [
+  "papers": [
     {
       "title": "CRISPR–Cas9 structures and mechanisms",
       "url": "https://www.annualreviews.org/doi/abs/10.1146/annurev-biophys-062215-010822",
@@ -249,7 +249,7 @@
       "relatedArticlesUrl": "https://scholar.google.com/scholar?q=related:41v0pVwGf-oJ:scholar.google.com/&scioq=crispr+cas9&hl=en&as_sdt=0,5"
     }
   ],
-  "count": 594000,
+  "totalPapers": 594000,
   "nextUrl": "https://scholar.google.com/scholar?start=10&q=crispr+cas9&hl=en&as_sdt=0,5",
   "prevUrl": null
 }

--- a/test/data/page2.json
+++ b/test/data/page2.json
@@ -1,5 +1,5 @@
 {
-  "results": [
+  "papers": [
     {
       "title": "[PDF][PDF] CRISPR/Cas9-based engineering of the epigenome",
       "url": "https://www.cell.com/cell-stem-cell/pdf/S1934-5909(17)30373-9.pdf",
@@ -226,7 +226,7 @@
       "relatedArticlesUrl": "https://scholar.google.com/scholar?q=related:p6f0gYTobnoJ:scholar.google.com/&scioq=crispr+cas9&hl=en&as_sdt=0,5"
     }
   ],
-  "count": 594000,
+  "totalPapers": 594000,
   "nextUrl": "https://scholar.google.com/scholar?start=20&q=crispr+cas9&hl=en&as_sdt=0,5",
   "prevUrl": "https://scholar.google.com/scholar?start=0&q=crispr+cas9&hl=en&as_sdt=0,5"
 }


### PR DESCRIPTION
- Add `iteratePages` that iterates through all search result pages,
- Refactor interfaces to make it more intuitive 
- Fix example scripts