### PR TITLE
feat: add iteratePapers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "bottleneck": "^2.19.5",
         "cheerio": "^1.0.0-rc.12",
-        "got": "^11.8.6"
+        "got": "^11.8.6",
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "@commitlint/cli": "^18.2.0",
@@ -24,6 +25,7 @@
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/npm": "^11.0.0",
         "@types/jest": "^29.4.0",
+        "@types/lodash": "^4.17.6",
         "conventional-changelog-conventionalcommits": "^7.0.2",
         "eslint": "^8.52.0",
         "husky": "^8.0.3",
@@ -2479,6 +2481,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.6.tgz",
+      "integrity": "sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==",
+      "dev": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.4",
@@ -8189,8 +8197,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/npm": "^11.0.0",
     "@types/jest": "^29.4.0",
+    "@types/lodash": "^4.17.6",
     "conventional-changelog-conventionalcommits": "^7.0.2",
     "eslint": "^8.52.0",
     "husky": "^8.0.3",
@@ -64,6 +65,7 @@
   "dependencies": {
     "bottleneck": "^2.19.5",
     "cheerio": "^1.0.0-rc.12",
-    "got": "^11.8.6"
+    "got": "^11.8.6",
+    "lodash": "^4.17.21"
   }
 }

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -1,5 +1,5 @@
 import { GoogleScholar } from './google-scholar'
-import { IPageContent, ISearchOptions } from './interfaces'
+import { IPageContent, IPaperMetadata, ISearchOptions } from './interfaces'
 import { SimpleWebClient } from './simple-web-client'
 
 const webClient = new SimpleWebClient()
@@ -29,4 +29,17 @@ export async function iteratePages(
   onPage: (page: IPageContent) => Promise<boolean>,
 ): Promise<void> {
   return googleScholar.iteratePages(opts, onPage)
+}
+
+/*
+ * Iterates through all search result papers,
+ * invoking the provided function on each paper until it returns false
+ * or there are no more papers.
+ */
+export async function iteratePapers(
+  opts: ISearchOptions,
+  onPaper: (paper: IPaperMetadata) => Promise<boolean>,
+  concurrency = 1,
+): Promise<void> {
+  return googleScholar.iteratePapers(opts, onPaper, concurrency)
 }


### PR DESCRIPTION
Add `iteratePapers` that iterates through all search result papers, invoking the provided function on each paper until:
- it returns `false`
- or there are no more papers.